### PR TITLE
Animated Emojiを読み上げないようにする

### DIFF
--- a/src/zundacord/utils.ts
+++ b/src/zundacord/utils.ts
@@ -2,7 +2,7 @@
 export function getReadableString(str: string): string {
     return str
         .replace(/https?:\/\/[^\s]+/, "") // http(s) url
-        .replace(/<.?:.+?(:.+?)?>/g, "") // discord textformats
+        .replace(/<a?:[^:]+:[0-9]+>/g, "") // discord emoji & Animated emoji
         .replace(/[^\p{L}\p{N}\p{P}\p{Z}]/gu, "") // unicode emoji
         .trim()
 }

--- a/src/zundacord/utils.ts
+++ b/src/zundacord/utils.ts
@@ -2,7 +2,7 @@
 export function getReadableString(str: string): string {
     return str
         .replace(/https?:\/\/[^\s]+/, "") // http(s) url
-        .replace(/<:.+?:.+?>/g, "") // discord emoji
+        .replace(/<.?:.+?(:.+?)?>/g, "") // discord textformats
         .replace(/[^\p{L}\p{N}\p{P}\p{Z}]/gu, "") // unicode emoji
         .trim()
 }

--- a/tests/zundacord/utils.test.ts
+++ b/tests/zundacord/utils.test.ts
@@ -6,6 +6,9 @@ test.each([
     // in, expected
     ["hello 🤔", "hello"],
     ["hello <:hello:1234567890>", "hello"],
+    ["hello animation <a:hello:1234567890>", "hello animation"],
+    ["test <:test:>", "test :test:"],
+    ["test <:test:<:test:>>", "test :test::test:"],
     ["😎😍😒 hello <:hello:1234567890> <:hello:1234567890> <:hello:1234567890>", "hello"],
     ["<:hello:1234567890> 😎 <:hello:1234567890> hello 🤔 <:hello:1234567890> 🤔", "hello"],
     ["12345hello54321", "12345hello54321"],

--- a/tests/zundacord/utils.test.ts
+++ b/tests/zundacord/utils.test.ts
@@ -7,8 +7,6 @@ test.each([
     ["hello 🤔", "hello"],
     ["hello <:hello:1234567890>", "hello"],
     ["hello animation <a:hello:1234567890>", "hello animation"],
-    ["test <:test:>", "test :test:"],
-    ["test <:test:<:test:>>", "test :test::test:"],
     ["😎😍😒 hello <:hello:1234567890> <:hello:1234567890> <:hello:1234567890>", "hello"],
     ["<:hello:1234567890> 😎 <:hello:1234567890> hello 🤔 <:hello:1234567890> 🤔", "hello"],
     ["12345hello54321", "12345hello54321"],


### PR DESCRIPTION
#31 で挙げられていたAnimated Emojiが読み上げられる問題を修正しました．
ついでにUnix Timestampが読み上げられていたのでそちらも併せて修正しました．

リファレンス
[Discord Developer Portal — Documentation — Reference](https://discord.com/developers/docs/reference#message-formatting)